### PR TITLE
Fixed volumes tag scan

### DIFF
--- a/terraform-coverage.sh
+++ b/terraform-coverage.sh
@@ -125,7 +125,7 @@ find_all_volumes () {
 }
 
 find_untagged_volumes () {
-  aws ec2 describe-volumes --region $AWS_REGION --profile "${AWS_PROFILE}"  --query "Volumes[].{ID: VolumeId}" --output json | jq -c '.[]' | grep -v $MANAGED_TAG
+  aws ec2 describe-volumes --region $AWS_REGION --profile "${AWS_PROFILE}"  --query "Volumes[].{ID: VolumeId,Tag: Tags[].Key}" --output json | jq -c '.[]' | grep -v $MANAGED_TAG
 }
 
 create_ec2_volumes_badge () {


### PR DESCRIPTION
Was using the same context in find_all_volumes as find_untagged_volumes ("Volumes[].{ID: VolumeId}") which doesn't appear to show tag information.

Perhaps just contextual change from prior aws json output? 